### PR TITLE
Update newsletter API endpoint to my.rcp

### DIFF
--- a/core/includes/admin/admin-pages.php
+++ b/core/includes/admin/admin-pages.php
@@ -637,22 +637,24 @@ add_action( 'admin_notices', 'restrict_content_admin_try_free_success' );
 function restrict_content_admin_try_free () {
 
 	if( isset( $_POST['rc_welcome_try_free_meta_nonce'] ) && wp_verify_nonce( $_POST['rc_welcome_try_free_meta_nonce'], 'rc_welcome_try_free_meta_nonce') ) {
-
-		$body = array(
-				'template_name' => 'rcp-demo-delivery',
-				'email' => $_POST['try_email_address']
+		$body = array (
+			'email' => $_POST['try_email_address'],
 		);
-
+		
 		$fields = array(
-				'method'        => 'POST',
-				'body'  => json_encode( $body )
+			'headers' => array( 'Content-Type' => 'application/json' ),
+			'body' => wp_json_encode( $body ),
 		);
 
-		$response = wp_remote_request( 'https://api.ithemes.com/email/send', $fields );
+		$rcp_newsletter_subscribe_api_url = defined( 'RCP_NEWSLETTER_SUBSCRIBE_API_URL' ) ? sanitize_url( RCP_NEWSLETTER_SUBSCRIBE_API_URL ) : 'https://my.restrictcontentpro.com/wp-json/my-rcp/v1/newsletter-subscribe';
 
-		if ( ! is_wp_error( $response ) && $_POST['source_page'] === 'welcome_page' ) {
+		$response = wp_remote_post( $rcp_newsletter_subscribe_api_url, $fields );
+
+		$is_response_error = ( 500 === $response["response"]["code"] );
+
+		if ( ! $is_response_error && $_POST['source_page'] === 'welcome_page' ) {
 			wp_redirect( add_query_arg( 'message', 'success', admin_url( 'admin.php?page=restrict-content-welcome' ) ) );
-		} else if ( ! is_wp_error( $response ) && $_POST['source_page'] === 'help_page' ) {
+		} else if ( ! $is_response_error && $_POST['source_page'] === 'help_page' ) {
 			wp_redirect( add_query_arg( 'message', 'success', admin_url( 'admin.php?page=rcp-need-help' ) ) );
 		} else {
 			wp_redirect( add_query_arg( 'message', 'failed', admin_url( 'admin.php?page=rcp-need-help' ) ) );


### PR DESCRIPTION
This PR updates the newsletter subscribe endpoint to be hosted on my.restrictcontentpro.com instead of api.ithemes.com.

It can be overridden with a wp-config.php line like this:

`define( 'RCP_NEWSLETTER_SUBSCRIBE_API_URL', 'https://myrcp.example.com/wp-json/my-rcp/v1/newsletter-subscribe' );`

![rc-artifact](https://user-images.githubusercontent.com/4604636/202766458-1f760a87-20b7-46d2-98fb-b76d6d59c7a9.png)

It looks like there are some code duplication related to this opt-in. This is just one of them.

Want to make sure this is all good before copying over to the others. I figure DRY-ing things up can be saved for another PR.