### PR TITLE
Fix correct 'plugins_loaded' hooking.

### DIFF
--- a/restrictcontent.php
+++ b/restrictcontent.php
@@ -105,7 +105,6 @@ final class RC_Requirements_Check
 
         // Always load translations
         add_action('plugins_loaded', array( $this, 'load_textdomain' ));
-        add_action('plugins_loaded', array( $this, 'plugins_loaded' ));
 
         // Load or quit
         $this->met()
@@ -255,6 +254,7 @@ final class RC_Requirements_Check
             // Bootstrap to plugins_loaded before priority 10 to make sure
             // add-ons are loaded after us.
             add_action('plugins_loaded', array( $this, 'bootstrap' ), 4);
+            add_action('plugins_loaded', array( $this, 'plugins_loaded' ));
 
             // Register the activation hook
             register_activation_hook($this->file, array( $this, 'install' ));

--- a/uninstall.php
+++ b/uninstall.php
@@ -23,6 +23,8 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) exit;
 // Load RCP file.
 include_once 'restrictcontent.php';
 
+use RCP\StellarWP\Telemetry\Uninstall;
+
 global $wpdb;
 $rcp_options = get_option( 'rcp_settings' );
 
@@ -99,4 +101,6 @@ if( isset( $rcp_options['remove_data_on_uninstall'] ) ) {
 	// Delete database version from options table.
 	$wpdb->query( "DELETE FROM $wpdb->options WHERE option_name = 'wpdb_restrict_content_pro_version'" );
 
+    // Remove Telemetry stuff.
+    Uninstall::run( 'restrict-content' );
 }


### PR DESCRIPTION
In some WordPress versions the hooking is executed in different order. Our tests hooking in the constructor worked okay, but in other websites it happend too fast the the class wasn't included on time. This change makes sure that the files are loaded before hooking to the 'plugins_loaded'.