### PR TITLE
Typehint parameters in accordance with ContainerInterface

### DIFF
--- a/vendor/strauss/lucatume/di52/src/Container.php
+++ b/vendor/strauss/lucatume/di52/src/Container.php
@@ -214,7 +214,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @throws ContainerException Error while retrieving the entry.
      */
-    public function get($id)
+    public function get(string $id)
     {
         try {
             return $this->resolver->resolve($id, [$id]);
@@ -299,7 +299,7 @@ class Container implements ArrayAccess, ContainerInterface
      *
      * @return bool Whether the container contains a binding for an id or not.
      */
-    public function has($id)
+    public function has(string $id)
     {
         return $this->resolver->isBound($id) || class_exists($id);
     }


### PR DESCRIPTION
Hi team!

We ran into an issue with the Restrict Content plugin and the WP CLI. We would get the following exception:

```
PHP Fatal error:  Declaration of Illuminate\Container\Container::get(string $id) must be compatible with Psr\Container\ContainerInterface::get($id) in /<redacted>/vendor/illuminate/container/Container.php on line 714
```

We pinpointed the issue to be in your plugin as disabling it, or typehinting the parameters as done in this PR, would resolve it.