### PR TITLE
Basic ZIP creation script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ vendor/wp-coding-standards/
 vendor/lucatume/
 vendor/psr/
 vendor/stellarwp/
+
+# QA ZIP generation.
+restrict-content/
+*.zip

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,13 @@
 		],
 		"post-update-cmd": [
 			"@strauss"
+		],
+		"qa:zip": [
+			"@composer install",
+			"@composer install --no-dev --no-scripts",
+			"git submodule update --init --recursive",
+			"rm -f ./restrict-content.zip",
+			"sh -c 'mkdir restrict-content && git ls-files --recurse-submodules -z | tar --null -T - -cf - | tar -xf - -C restrict-content && zip -r restrict-content.zip restrict-content && rm -rf restrict-content'"
 		]
 	},
 	"require": {


### PR DESCRIPTION
This gives us the ability to quickly generate a ZIP for QA.

This is not ideal. It would be much better to handle this via a CI workflow. But it will work for now.

Copy of https://github.com/ithemes/better-wp-security/pull/28 as it is the same issue