### PR TITLE
Change textdomain loading hook to 'init'

### DIFF
--- a/restrictcontent.php
+++ b/restrictcontent.php
@@ -105,7 +105,14 @@ final class RC_Requirements_Check
         $this->base = plugin_basename($this->file);
 
         // Always load translations
-        add_action('plugins_loaded', array( $this, 'load_textdomain' ));
+        // add_action('plugins_loaded', array( $this, 'load_textdomain' )); 
+		/* This is giving errors in WP.
+		* This hooks RC's textdomain loader to plugins_loaded — which fires before init. 
+		* WordPress 6.7+ specifically warns about this. Translations should always be hooked at init or later.
+		* RC's own legacy path gets it right. In legacy/restrictcontent.php line 47:
+		* 	add_action( 'init', 'rc_textdomain' );
+		*/
+		add_action('init', array( $this, 'load_textdomain' ));
 
         // Load or quit
         $this->met()


### PR DESCRIPTION
Updated textdomain loading to hook at 'init' instead of 'plugins_loaded' to avoid warnings in WordPress 6.7.

[27-Apr-2026 11:45:20 UTC] PHP Notice: Function _load_textdomain_just_in_time was called <strong>incorrectly</strong>. Translation loading for the <code>rcp</code> domain was triggered too early. This is usually an indicator for some code in the plugin or theme running too early. Translations should be loaded at the <code>init</code> action or later. Please see <a href="https://developer.wordpress.org/advanced-administration/debug/debug-wordpress/">Debugging in WordPress</a> for more information. (This message was added in version 6.7.0.) in /home/ACCOUNT/DOMAIN/wp-includes/functions.php on line 6131