### PR TITLE
Fix WP Approve User integration for v12+ three-state meta

### DIFF
--- a/core/includes/integrations/class-rcp-wp-approve-user.php
+++ b/core/includes/integrations/class-rcp-wp-approve-user.php
@@ -60,7 +60,13 @@ class RCP_WP_Approve_User {
 	 * @return  bool
 	 */
 	private function is_pending( $user_id = 0 ) {
-		return (bool) is_user_logged_in() && ! get_user_meta( $user_id, 'wp-approve-user', true ) && ! user_can( $user_id, 'edit_pages' );
+		if ( ! is_user_logged_in() || user_can( $user_id, 'edit_pages' ) ) {
+			return false;
+		}
+
+		$status = get_user_meta( $user_id, 'wp-approve-user', true );
+
+		return 'approved' !== $status && true !== $status && '1' !== $status;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

[WP Approve User v12](https://wordpress.org/plugins/wp-approve-user/#developers) switched the `wp-approve-user` user meta from a boolean to a three-state string: `'approved'`, `'pending'`, or `'unapproved'`. The integration's `is_pending()` check at `core/includes/integrations/class-rcp-wp-approve-user.php:63` still treats the meta as a boolean:

```php
return (bool) is_user_logged_in()
    && ! get_user_meta( $user_id, 'wp-approve-user', true )
    && ! user_can( $user_id, 'edit_pages' );
```

Every v12+ string is truthy, so `! $meta` is always `false`. Pending and unapproved users surface as approved and gain access to content that should be restricted.

## Fix

Compare the stored value against the canonical v12+ string (`'approved'`) and the legacy `'1'` boolean still present on pre-v12 installs. Anything else is treated as pending. This is forward- and backward-compatible across WP Approve User versions.

```php
return 'approved' !== $status && true !== $status && '1' !== $status;
```

## Test plan

- [ ] Activate WP Approve User v12+, register a user (status `'pending'`), log in as that user, and confirm they cannot view content gated by `[restrict]` or post-level RCP restrictions.
- [ ] Unapprove an approved user (status `'unapproved'`) and confirm they are blocked from restricted content on next page load.
- [ ] Approve a pending user via the RCP member-row "Approve" action and confirm they regain access.
- [ ] On a site running WP Approve User v11 or earlier (legacy boolean storage), confirm approve/unapprove still work — the `'1'` and empty-string code paths must keep functioning.