### PR TITLE
feat: add "CNY" currency

### DIFF
--- a/core/includes/misc-functions.php
+++ b/core/includes/misc-functions.php
@@ -159,6 +159,9 @@ function rcp_get_currency_symbol( $currency = false ) {
 		case 'CHF':
 			$symbol = '&#67;&#72;&#70;';
 			break;
+		case 'CNY':
+			$symbol = '&#20803;';
+			break;
 		case 'CZK':
 			$symbol = '&#75;&#269;';
 			break;
@@ -256,6 +259,7 @@ function rcp_get_currencies() {
 		'SGD' => __( 'Singapore Dollar (&#36;)', 'rcp' ),
 		'SEK' => __( 'Swedish Krona (&#107;&#114;)', 'rcp' ),
 		'CHF' => __( 'Swiss Franc (&#67;&#72;&#70;)', 'rcp' ),
+		'CNY' => __( 'Chinese Yuan (&#20803;)', 'rcp' ),
 		'TWD' => __( 'Taiwan New Dollars (&#78;&#84;&#36;)', 'rcp' ),
 		'THB' => __( 'Thai Baht (&#3647;)', 'rcp' ),
 		'TRY' => __( 'Turkish Lira (&#8356;)', 'rcp' ),


### PR DESCRIPTION
Solves [SMTNC-1513](https://linear.app/nexcess/issue/SMTNC-1513/chinese-yuan-should-be-part-of-the-currencies)

Together with https://github.com/stellarwp/restrict-content-pro/pull/199

Adds Chinese Yuan (CNY) with the 元 symbol as a supported currency in the plugin settings, currency symbol mapping, and currency list.

<img width="1166" height="989" alt="image" src="https://github.com/user-attachments/assets/1cdd7594-f50c-4321-bc7c-e506ba24422c" />