### PR TITLE
Restore the 4.0.1 security release to master

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "restrictcontent/restrict-content",
-	"version": "3.2.26",
+	"version": "4.0.1",
 	"type": "wordpress-plugin",
 	"description": "A simple, yet powerful membership solution for WordPress.",
 	"keywords": [ "rcp", "pippin", "membership"],

--- a/legacy/includes/forms.php
+++ b/legacy/includes/forms.php
@@ -239,8 +239,8 @@ function rc_process_lost_password_form() {
 	$errors = rc_send_password_reset_email();
 
 	if ( ! is_wp_error( $errors ) ) {
-		$redirect_to = esc_url( $_POST['rc_redirect'] ) . '?rc_action=lostpassword_checkemail';
-		wp_redirect( $redirect_to );
+		$redirect_base = wp_validate_redirect( isset( $_POST['rc_redirect'] ) ? sanitize_url( wp_unslash( $_POST['rc_redirect'] ) ) : '', home_url() ); // phpcs:ignore WordPress.WP.DeprecatedFunctions.sanitize_urlFound, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		wp_safe_redirect( add_query_arg( 'rc_action', 'lostpassword_checkemail', $redirect_base ) );
 		exit();
 	}
 }
@@ -303,7 +303,17 @@ function rc_send_password_reset_email() {
 	$message .= sprintf( __( 'Username: %s', 'restrict-content' ), $user_login ) . "\r\n\r\n";
 	$message .= __( 'If this was a mistake, just ignore this email and nothing will happen.', 'restrict-content' ) . "\r\n\r\n";
 	$message .= __( 'To reset your password, visit the following address:', 'restrict-content' ) . "\r\n\r\n";
-	$message .= esc_url_raw( add_query_arg( array( 'rc_action' => 'lostpassword_reset', 'key' => $key, 'login' => rawurlencode( $user_login ) ), $_POST['rc_redirect'] ) ) . "\r\n";
+	$redirect_base = wp_validate_redirect( isset( $_POST['rc_redirect'] ) ? sanitize_url( wp_unslash( $_POST['rc_redirect'] ) ) : '', home_url() ); // phpcs:ignore WordPress.Security.NonceVerification.Missing, WordPress.WP.DeprecatedFunctions.sanitize_urlFound, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	$message .= esc_url_raw(
+		add_query_arg(
+			array(
+				'rc_action' => 'lostpassword_reset',
+				'key'       => $key,
+				'login'     => rawurlencode( $user_login ),
+			),
+			$redirect_base
+		)
+	) . "\r\n";
 
 	if ( is_multisite() ) {
 

--- a/legacy/restrictcontent.php
+++ b/legacy/restrictcontent.php
@@ -21,7 +21,7 @@ if( false === $rc_options ) {
 }
 
 if ( ! defined( 'RC_PLUGIN_VERSION' ) ) {
-	define( 'RC_PLUGIN_VERSION', '4.0.0' );
+	define( 'RC_PLUGIN_VERSION', '4.0.1');
 }
 
 if ( ! defined( 'RC_PLUGIN_DIR' ) ) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restrict-content",
-  "version": "3.2.26",
+  "version": "4.0.1",
   "description": "Set up a complete membership system for your WordPress site and deliver premium content to your members. Unlimited membership packages, membership management, discount codes, registration / login forms, and more.",
   "homepage": "https://restrictcontentpro.com/",
   "author": "iThemes <support@restrictcontentpro.com> (https://ithemes.com/)",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: restrict pages, restrict posts, restrict access, membership, registration 
 Requires at least: 6.0
 Requires PHP: 7.4
 Tested up to: 6.9
-Stable tag: 4.0.0
+Stable tag: 4.0.1
 
 Kadence Memberships is a powerful WordPress membership plugin that gives you full control over who can and cannot view content on your WordPress site.
 

--- a/readme.txt
+++ b/readme.txt
@@ -257,6 +257,9 @@ https://restrictcontentpro.com/tour/screenshots/
 
 == Changelog ==
 
+= 4.0.1 =
+* Security: Strengthened security measures for password recovery.
+
 = 4.0.0 =
 * Tweak: Plugin name changed to be "Kadence Memberships".
 * Tweak: Updated branding references from StellarWP to Nexcess.

--- a/restrictcontent.php
+++ b/restrictcontent.php
@@ -3,7 +3,7 @@
  * Plugin Name: Kadence Memberships
  * Plugin URI: https://restrictcontentpro.com
  * Description: Set up a complete membership system for your WordPress site and deliver premium content to your members. Unlimited membership packages, membership management, discount codes, registration / login forms, and more.
- * Version: 4.0.0
+ * Version: 4.0.1
  * Author: Kadence
  * Author URI: https://www.kadencewp.com/
  * Requires at least: 6.0

--- a/restrictcontent.php
+++ b/restrictcontent.php
@@ -18,7 +18,7 @@ defined('ABSPATH') || exit;
 define('RCP_PLUGIN_FILE', __FILE__);
 define('RCP_ROOT', plugin_dir_path(__FILE__));
 define('RCP_WEB_ROOT', plugin_dir_url(__FILE__));
-define('RCF_VERSION', '4.0.0');
+define('RCF_VERSION', '4.0.1');
 
 // Load Strauss autoload.
 require_once plugin_dir_path( __FILE__ ) . 'vendor/strauss/autoload.php';


### PR DESCRIPTION
## Summary

Version 4.0.1 was published to WordPress.org on 2026-05-26 but was never merged into `master`. This PR merges `SVUL-1` — the branch 4.0.1 was cut from — to bring GitHub back in sync with the released product.

`master` is currently **one security release behind what users are running.**

## How this was confirmed

- Downloaded `restrict-content.4.0.1.zip` from WordPress.org. Its `legacy/includes/forms.php` is **byte-identical** to this branch's version, confirming `SVUL-1` is the code that shipped as 4.0.1.
- The wp.org API reports `version: 4.0.1`, `last_updated: 2026-05-26 8:14pm GMT`.
- `master`'s `readme.txt` differs from the shipped 4.0.1 readme in exactly two places: the `Stable tag` line and the missing `= 4.0.1 =` changelog block — both restored here.

## Why this is urgent

The vulnerable code is still live on `master`. `rc_process_lost_password_form()` is hooked on `init` (`legacy/includes/forms.php:247`) and legacy is loaded unconditionally from `restrictcontent.php:248`.

The more serious of the two issues is at `legacy/includes/forms.php:306`, where an unvalidated `$_POST['rc_redirect']` is used as the base URL for the password-reset link that gets **emailed to the user**:

```php
$message .= esc_url_raw( add_query_arg( array( 'rc_action' => 'lostpassword_reset', 'key' => $key, ... ), $_POST['rc_redirect'] ) )
```

A crafted `rc_redirect` causes the reset key to be delivered on an attacker-controlled host — password-reset token leakage, not merely an open redirect. Line 242 is a plain open redirect via `wp_redirect()`; `esc_url()` does not constrain the host.

Both are fixed here by routing the value through `wp_validate_redirect()` with a `home_url()` fallback and switching to `wp_safe_redirect()` / `add_query_arg()`.

**Until this merges, any release tagged above 4.0.1 off `master` would reintroduce this vulnerability to every site that already auto-updated to 4.0.1.**

## Changes

| File | Change |
| --- | --- |
| `legacy/includes/forms.php` | Validate `rc_redirect` in the lost-password flow (the security fix) |
| `readme.txt` | `Stable tag` → 4.0.1, add `= 4.0.1 =` changelog entry |
| `restrictcontent.php` | Header `Version` and `RCF_VERSION` → 4.0.1 |
| `legacy/restrictcontent.php` | `RC_PLUGIN_VERSION` → 4.0.1 |
| `composer.json` | `version` → 4.0.1 (was stale at 3.2.26) |
| `package.json` | `version` → 4.0.1 (was stale at 3.2.26) |

Merges cleanly into `master` with no conflicts; the branch is based directly on current `master` (`2b18f41`) with no divergence.

## Deliberately not changed

This branch is left byte-identical to the released 4.0.1 artifact, so `package-lock.json` is **not** touched here and remains stale at `3.2.26`. It is brought in line in the follow-up 4.0.2 PR.

`core/includes/class-restrict-content.php:29` `const VERSION` also stays at `4.0.0`, and that is **correct** — it tracks the restrict-content-pro **core** version (historically 3.5.57 → 3.5.58.1 → 3.5.59, then set to 4.0.0 by `953fc70` when `core/` was synced from the pro repo), not this plugin's version. It should only move on a `core/` sync.

## Follow-up

- A 4.0.2 PR adding the CNY currency will follow on top of this one.
- `fix/svul-1` is a separate unmerged branch with broader hardening of the same file (also covers lines 168, 444/451/453, 604, and adds a missing `exit` after `wp_safe_redirect()` in the key-error paths). Worth a separate review to decide whether that belongs in 4.0.2.