### PR TITLE
Release 4.0.2 — add Chinese Yuan (CNY) currency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "restrictcontent/restrict-content",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"type": "wordpress-plugin",
 	"description": "A simple, yet powerful membership solution for WordPress.",
 	"keywords": [ "rcp", "pippin", "membership"],

--- a/core/includes/misc-functions.php
+++ b/core/includes/misc-functions.php
@@ -159,6 +159,9 @@ function rcp_get_currency_symbol( $currency = false ) {
 		case 'CHF':
 			$symbol = '&#67;&#72;&#70;';
 			break;
+		case 'CNY':
+			$symbol = '&#20803;';
+			break;
 		case 'CZK':
 			$symbol = '&#75;&#269;';
 			break;
@@ -256,6 +259,7 @@ function rcp_get_currencies() {
 		'SGD' => __( 'Singapore Dollar (&#36;)', 'rcp' ),
 		'SEK' => __( 'Swedish Krona (&#107;&#114;)', 'rcp' ),
 		'CHF' => __( 'Swiss Franc (&#67;&#72;&#70;)', 'rcp' ),
+		'CNY' => __( 'Chinese Yuan (&#20803;)', 'rcp' ),
 		'TWD' => __( 'Taiwan New Dollars (&#78;&#84;&#36;)', 'rcp' ),
 		'THB' => __( 'Thai Baht (&#3647;)', 'rcp' ),
 		'TRY' => __( 'Turkish Lira (&#8356;)', 'rcp' ),

--- a/legacy/restrictcontent.php
+++ b/legacy/restrictcontent.php
@@ -21,7 +21,7 @@ if( false === $rc_options ) {
 }
 
 if ( ! defined( 'RC_PLUGIN_VERSION' ) ) {
-	define( 'RC_PLUGIN_VERSION', '4.0.1');
+	define( 'RC_PLUGIN_VERSION', '4.0.2' );
 }
 
 if ( ! defined( 'RC_PLUGIN_DIR' ) ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "restrict-content",
-  "version": "3.2.26",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "3.2.26",
+      "version": "4.0.2",
       "license": "GPLv2+",
       "dependencies": {
         "@wordpress/block-editor": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restrict-content",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "description": "Set up a complete membership system for your WordPress site and deliver premium content to your members. Unlimited membership packages, membership management, discount codes, registration / login forms, and more.",
   "homepage": "https://restrictcontentpro.com/",
   "author": "iThemes <support@restrictcontentpro.com> (https://ithemes.com/)",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tags: restrict pages, restrict posts, restrict access, membership, registration 
 Requires at least: 6.0
 Requires PHP: 7.4
 Tested up to: 6.9
-Stable tag: 4.0.1
+Stable tag: 4.0.2
 
 Kadence Memberships is a powerful WordPress membership plugin that gives you full control over who can and cannot view content on your WordPress site.
 
@@ -256,6 +256,9 @@ Go to the demo page to see examples:
 https://restrictcontentpro.com/tour/screenshots/
 
 == Changelog ==
+
+= 4.0.2 =
+* New: Added Chinese Yuan (&#20803;) to the list of available currencies.
 
 = 4.0.1 =
 * Security: Strengthened security measures for password recovery.

--- a/restrictcontent.php
+++ b/restrictcontent.php
@@ -3,7 +3,7 @@
  * Plugin Name: Kadence Memberships
  * Plugin URI: https://restrictcontentpro.com
  * Description: Set up a complete membership system for your WordPress site and deliver premium content to your members. Unlimited membership packages, membership management, discount codes, registration / login forms, and more.
- * Version: 4.0.1
+ * Version: 4.0.2
  * Author: Kadence
  * Author URI: https://www.kadencewp.com/
  * Requires at least: 6.0
@@ -18,7 +18,7 @@ defined('ABSPATH') || exit;
 define('RCP_PLUGIN_FILE', __FILE__);
 define('RCP_ROOT', plugin_dir_path(__FILE__));
 define('RCP_WEB_ROOT', plugin_dir_url(__FILE__));
-define('RCF_VERSION', '4.0.1');
+define('RCF_VERSION', '4.0.2');
 
 // Load Strauss autoload.
 require_once plugin_dir_path( __FILE__ ) . 'vendor/strauss/autoload.php';


### PR DESCRIPTION
## Summary

Release 4.0.2 — adds Chinese Yuan (CNY) as a selectable currency.

> [!IMPORTANT]
> **Stacked on #50.** This branch includes the `SVUL-1` merge that restores the shipped 4.0.1 security fix. #50 must merge first, otherwise this PR would tag 4.0.2 off a `master` that is missing the 4.0.1 password-recovery fix and reintroduce that vulnerability to every site already on 4.0.1. Once #50 lands, the `SVUL-1` commits here become a no-op and the effective diff is just the CNY change plus the version bump.

## Changes

**Feature** (`core/includes/misc-functions.php`, from #49):
- `CNY` added to `rcp_get_currency_symbol()` with symbol `&#20803;` (元, U+5143)
- `CNY` added to `rcp_get_currencies()` as `Chinese Yuan (&#20803;)`

**Version bump** 4.0.1 → 4.0.2:

| File | Field |
| --- | --- |
| `restrictcontent.php` | header `Version`, `RCF_VERSION` |
| `legacy/restrictcontent.php` | `RC_PLUGIN_VERSION` |
| `readme.txt` | `Stable tag`, `= 4.0.2 =` changelog entry |
| `composer.json` | `version` |
| `package.json` | `version` |
| `package-lock.json` | `version` (×2) — was stale at 3.2.26, brought in line |

## Review notes

- **Both currency registries were updated.** A new currency must land in `rcp_get_currency_symbol()` *and* `rcp_get_currencies()`. Missing the list means `rcp_get_currency_symbol()` rejects it and falls back to the configured currency (`misc-functions.php:135-138`); missing the switch means the symbol renders as the literal string `CNY`.
- **Zero-decimal handling is correct.** CNY is intentionally absent from `rcp_is_zero_decimal_currency()` (`misc-functions.php:1171`), so Stripe's ×100 minor-unit conversion at `core/includes/gateways/stripe/functions.php:393` applies as it should. This is the usual failure point when adding a currency.
- No other currency enumerations exist in the codebase — no JS-side list needs syncing.
- `core/includes/class-restrict-content.php` `const VERSION` is deliberately left at `4.0.0`. It tracks the restrict-content-pro **core** version (historically 3.5.57 → 3.5.58.1 → 3.5.59, then set to 4.0.0 by `953fc70` when `core/` was synced from the pro repo), not this plugin's version. It should only move on a `core/` sync. This corrects a claim in #50's description.
- `php -l` clean on all touched PHP; all three JSON manifests parse.

## Optional follow-up (not addressed here)

In `rcp_get_currencies()` the list is ordered alphabetically by label, but `'CNY'` was inserted after `'CHF'` (Swiss Franc) rather than between `'CAD'` and `'CZK'`. Cosmetic — it only affects ordering in the admin currency dropdown. Left as-is to keep this release PR to the bump; happy to fold it in if preferred.
